### PR TITLE
Add Fintech Learn site with course pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,12 +4,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CryptoLearn - Market Tracking & Educational App</title>
-    <meta name="description" content="Track cryptocurrency markets and learn about fintech in one place" />
-    <meta name="author" content="CryptoLearn" />
+    <title>Fintech Learn - Educational App</title>
+    <meta name="description" content="Learn finance and fintech with interactive courses" />
+    <meta name="author" content="Fintech Learn" />
 
-    <meta property="og:title" content="CryptoLearn - Market Tracking & Educational App" />
-    <meta property="og:description" content="Track cryptocurrency markets and learn about fintech in one place" />
+    <meta property="og:title" content="Fintech Learn - Educational App" />
+    <meta property="og:description" content="Learn finance and fintech with interactive courses" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
 

--- a/index.html
+++ b/index.html
@@ -4,12 +4,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CryptoLearn - Market Tracking & Educational App</title>
-    <meta name="description" content="Track cryptocurrency markets and learn about fintech in one place" />
-    <meta name="author" content="CryptoLearn" />
+    <title>Fintech Learn - Educational App</title>
+    <meta name="description" content="Learn finance and fintech with interactive courses" />
+    <meta name="author" content="Fintech Learn" />
 
-    <meta property="og:title" content="CryptoLearn - Market Tracking & Educational App" />
-    <meta property="og:description" content="Track cryptocurrency markets and learn about fintech in one place" />
+    <meta property="og:title" content="Fintech Learn - Educational App" />
+    <meta property="og:description" content="Learn finance and fintech with interactive courses" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,13 +7,8 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/hooks/useAuth";
 import Index from "./pages/Index";
 import CoinDetail from "./pages/CoinDetail";
-import Learn from "./pages/Learn";
-import BlockchainFundamentals from "./pages/BlockchainFundamentals";
-import TradingBasics from "./pages/TradingBasics";
-import CryptoWallets from "./pages/CryptoWallets";
-import DefiExplained from "./pages/DefiExplained";
-import NftBasics from "./pages/NftBasics";
-import TechnicalAnalysis from "./pages/TechnicalAnalysis";
+import Courses from "./pages/Courses";
+import CourseDetail from "./pages/CourseDetail";
 import Contact from "./pages/Contact";
 import NotFound from "./pages/NotFound";
 
@@ -29,13 +24,8 @@ const App = () => (
           <Routes>
             <Route path="/" element={<Index />} />
             <Route path="/coin/:id" element={<CoinDetail />} />
-            <Route path="/learn" element={<Learn />} />
-            <Route path="/learn/blockchain-fundamentals" element={<BlockchainFundamentals />} />
-            <Route path="/learn/trading-basics" element={<TradingBasics />} />
-            <Route path="/learn/crypto-wallets" element={<CryptoWallets />} />
-            <Route path="/learn/defi-explained" element={<DefiExplained />} />
-            <Route path="/learn/nft-basics" element={<NftBasics />} />
-            <Route path="/learn/technical-analysis" element={<TechnicalAnalysis />} />
+            <Route path="/courses" element={<Courses />} />
+            <Route path="/courses/:courseId" element={<CourseDetail />} />
             <Route path="/contact" element={<Contact />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />

--- a/src/components/CourseCarousel.tsx
+++ b/src/components/CourseCarousel.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { courses } from '@/data/courses';
+import { Link } from 'react-router-dom';
+
+const CourseCarousel = () => {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % courses.length);
+    }, 4000);
+    return () => clearInterval(id);
+  }, []);
+
+  const visible = courses.slice(index, index + 3);
+  if (visible.length < 3) {
+    visible.push(...courses.slice(0, 3 - visible.length));
+  }
+
+  return (
+    <div className="overflow-hidden">
+      <div className="flex transition-all" style={{ transform: 'translateX(0)' }}>
+        {visible.map((course) => (
+          <Link key={course.id} to={`/courses/${course.id}`} className="crypto-card mr-4 w-72 flex-shrink-0">
+            <img src={course.image} alt={course.title} className="h-32 w-full object-cover" />
+            <div className="p-3">
+              <h3 className="font-medium text-sm mb-1">{course.title}</h3>
+              <p className="text-xs text-muted-foreground">{course.description}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CourseCarousel;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -49,22 +49,22 @@ const Header = () => {
             <div className="h-8 w-8 rounded-full crypto-gradient flex items-center justify-center">
               <TrendingUp className="h-5 w-5 text-white" />
             </div>
-            <span className="font-bold text-xl hidden md:block">CryptoLearn</span>
+            <span className="font-bold text-xl hidden md:block">Fintech Learn</span>
           </Link>
         </div>
 
         <nav className="hidden md:flex items-center gap-6">
-          <Link 
-            to="/" 
+          <Link
+            to="/"
             className={`text-sm font-medium transition-colors hover:text-primary ${isActive('/') ? 'text-primary' : 'text-muted-foreground'}`}
           >
-            Markets
+            Home
           </Link>
-          <Link 
-            to="/learn" 
-            className={`text-sm font-medium transition-colors hover:text-primary ${isActive('/learn') ? 'text-primary' : 'text-muted-foreground'}`}
+          <Link
+            to="/courses"
+            className={`text-sm font-medium transition-colors hover:text-primary ${isActive('/courses') ? 'text-primary' : 'text-muted-foreground'}`}
           >
-            Learn
+            Courses
           </Link>
           <Link 
             to="/contact" 

--- a/src/components/TrendingCoins.tsx
+++ b/src/components/TrendingCoins.tsx
@@ -4,58 +4,39 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import CoinCard from "./CoinCard";
 
-// Mock data for demonstration
-const mockTrendingCoins = [
-  {
-    id: "bitcoin",
-    name: "Bitcoin",
-    symbol: "btc",
-    price: 63452.12,
-    change24h: 2.34,
-    image: "https://assets.coingecko.com/coins/images/1/large/bitcoin.png"
-  },
-  {
-    id: "ethereum",
-    name: "Ethereum",
-    symbol: "eth",
-    price: 3421.87,
-    change24h: 1.67,
-    image: "https://assets.coingecko.com/coins/images/279/large/ethereum.png"
-  },
-  {
-    id: "solana",
-    name: "Solana",
-    symbol: "sol",
-    price: 143.26,
-    change24h: -3.21,
-    image: "https://assets.coingecko.com/coins/images/4128/large/solana.png"
-  },
-  {
-    id: "cardano",
-    name: "Cardano",
-    symbol: "ada",
-    price: 0.45,
-    change24h: -0.82,
-    image: "https://assets.coingecko.com/coins/images/975/large/cardano.png"
-  }
-];
+interface Coin {
+  id: string;
+  name: string;
+  symbol: string;
+  price: number;
+  change24h: number;
+  image: string;
+}
 
 const TrendingCoins = () => {
-  const [trending, setTrending] = useState<typeof mockTrendingCoins | null>(null);
+  const [trending, setTrending] = useState<Coin[] | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // Simulating API fetch
     const fetchTrending = async () => {
       setLoading(true);
       try {
-        // In a real app, this would be an API call
-        setTimeout(() => {
-          setTrending(mockTrendingCoins);
-          setLoading(false);
-        }, 1000);
+        const res = await fetch(
+          'https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=4&page=1&sparkline=false'
+        );
+        const data = await res.json();
+        const coins: Coin[] = data.map((c: any) => ({
+          id: c.id,
+          name: c.name,
+          symbol: c.symbol,
+          price: c.current_price,
+          change24h: c.price_change_percentage_24h,
+          image: c.image,
+        }));
+        setTrending(coins);
+        setLoading(false);
       } catch (error) {
-        console.error("Error fetching trending coins:", error);
+        console.error('Error fetching trending coins:', error);
         setLoading(false);
       }
     };

--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -1,0 +1,152 @@
+export interface CourseModule {
+  title: string;
+  lessons: string[];
+}
+
+export interface Course {
+  id: string;
+  title: string;
+  description: string;
+  overview: string;
+  image: string;
+  modules: CourseModule[];
+}
+
+export const courses: Course[] = [
+  {
+    id: 'blockchain',
+    title: 'Blockchain & Distributed Ledger Technology',
+    description: 'Understand how blockchains work and why they matter.',
+    overview: 'This course introduces the fundamentals of blockchain and distributed ledger technology.',
+    image: 'https://images.unsplash.com/photo-1581091012184-7c93de72f67b?auto=format&w=800',
+    modules: [
+      {
+        title: 'Introduction to Blockchain',
+        lessons: ['What is a ledger?', 'Consensus mechanisms']
+      },
+      {
+        title: 'Real-World Applications',
+        lessons: ['Smart contracts', 'Use cases']
+      }
+    ]
+  },
+  {
+    id: 'defi',
+    title: 'Decentralized Finance (DeFi)',
+    description: 'Explore financial services built on public blockchains.',
+    overview: 'Learn how DeFi is changing lending, borrowing and trading.',
+    image: 'https://images.unsplash.com/photo-1611078489935-0cb9649c779b?auto=format&w=800',
+    modules: [
+      {
+        title: 'DeFi Basics',
+        lessons: ['What is DeFi?', 'Benefits and risks']
+      },
+      {
+        title: 'Popular Protocols',
+        lessons: ['Decentralized exchanges', 'Lending platforms']
+      }
+    ]
+  },
+  {
+    id: 'payments',
+    title: 'Digital Payments & Embedded Finance',
+    description: 'Discover modern payment rails and integration.',
+    overview: 'Understand how digital wallets and embedded finance enable seamless transactions.',
+    image: 'https://images.unsplash.com/photo-1518544881718-6d6dbb5ccb7a?auto=format&w=800',
+    modules: [
+      {
+        title: 'Payments 101',
+        lessons: ['Payment processors', 'Mobile wallets']
+      },
+      {
+        title: 'Embedded Finance',
+        lessons: ['Banking as a service', 'Fintech APIs']
+      }
+    ]
+  },
+  {
+    id: 'ai-ml',
+    title: 'AI & Machine Learning in Finance',
+    description: 'See how algorithms help make financial decisions.',
+    overview: 'This course covers machine learning techniques used in finance from trading to credit scoring.',
+    image: 'https://images.unsplash.com/photo-1534759846116-579a091b1aab?auto=format&w=800',
+    modules: [
+      {
+        title: 'ML Basics',
+        lessons: ['Supervised vs unsupervised', 'Model evaluation']
+      },
+      {
+        title: 'Finance Applications',
+        lessons: ['Algorithmic trading', 'Risk management']
+      }
+    ]
+  },
+  {
+    id: 'crypto-assets',
+    title: 'Cryptocurrencies & Digital Assets',
+    description: 'Learn about Bitcoin, Ethereum and other digital assets.',
+    overview: 'Examine how cryptocurrencies are created, traded and stored.',
+    image: 'https://images.unsplash.com/photo-1629878288481-e54ef09bfd8f?auto=format&w=800',
+    modules: [
+      {
+        title: 'Major Coins',
+        lessons: ['Bitcoin overview', 'Ethereum ecosystem']
+      },
+      {
+        title: 'Storing Assets',
+        lessons: ['Wallet types', 'Security best practices']
+      }
+    ]
+  },
+  {
+    id: 'cybersecurity',
+    title: 'Cybersecurity in Fintech',
+    description: 'Keep financial technology safe from threats.',
+    overview: 'Understand common fintech security risks and how to mitigate them.',
+    image: 'https://images.unsplash.com/photo-1605902711622-cfb43c44367f?auto=format&w=800',
+    modules: [
+      {
+        title: 'Threat Landscape',
+        lessons: ['Phishing', 'Social engineering']
+      },
+      {
+        title: 'Protecting Data',
+        lessons: ['Encryption basics', 'Regulations']
+      }
+    ]
+  },
+  {
+    id: 'wealthtech',
+    title: 'Robo-Advisors & WealthTech',
+    description: 'Automated investing platforms explained.',
+    overview: 'Learn how robo-advisors use algorithms to manage portfolios.',
+    image: 'https://images.unsplash.com/photo-1551836022-d5d88e9218df?auto=format&w=800',
+    modules: [
+      {
+        title: 'How Robo-Advisors Work',
+        lessons: ['Asset allocation', 'Rebalancing']
+      },
+      {
+        title: 'Future of WealthTech',
+        lessons: ['Personalization', 'Regulation challenges']
+      }
+    ]
+  },
+  {
+    id: 'insurtech',
+    title: 'InsurTech',
+    description: 'Innovation in the insurance industry.',
+    overview: 'Explore how technology is transforming insurance products and services.',
+    image: 'https://images.unsplash.com/photo-1581091012184-7e0b6e649e60?auto=format&w=800',
+    modules: [
+      {
+        title: 'Digital Insurance Basics',
+        lessons: ['Telematics', 'Usage-based policies']
+      },
+      {
+        title: 'Claims Automation',
+        lessons: ['AI for claims', 'Fraud detection']
+      }
+    ]
+  }
+];

--- a/src/pages/BlockchainFundamentals.tsx
+++ b/src/pages/BlockchainFundamentals.tsx
@@ -690,7 +690,7 @@ contract Escrow {
 
       <footer className="border-t border-border py-6 mt-auto">
         <div className="container px-4 text-center text-sm text-muted-foreground">
-          <p>© 2025 CryptoLearn. All rights reserved.</p>
+          <p>© 2025 Fintech Learn. All rights reserved.</p>
           <p className="mt-1">Educational content provided for informational purposes only.</p>
         </div>
       </footer>

--- a/src/pages/CoinDetail.tsx
+++ b/src/pages/CoinDetail.tsx
@@ -304,8 +304,7 @@ const CoinDetail = () => {
       
       <footer className="border-t border-border py-6">
         <div className="container px-4 text-center text-sm text-muted-foreground">
-          <p>© 2025 CryptoLearn. All rights reserved.</p>
-          <p className="mt-1">Market data provided for educational purposes only.</p>
+          <p>© 2025 Fintech Learn. All rights reserved.</p>
         </div>
       </footer>
     </div>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -116,8 +116,7 @@ const Contact = () => {
       
       <footer className="border-t border-border py-6">
         <div className="container px-4 text-center text-sm text-muted-foreground">
-          <p>© 2025 CryptoLearn. All rights reserved.</p>
-          <p className="mt-1">Market data provided for educational purposes only.</p>
+          <p>© 2025 Fintech Learn. All rights reserved.</p>
         </div>
       </footer>
     </div>

--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -1,0 +1,50 @@
+import { useParams, Link } from 'react-router-dom';
+import { courses } from '@/data/courses';
+import Header from '@/components/Header';
+
+const CourseDetail = () => {
+  const { courseId } = useParams();
+  const course = courses.find(c => c.id === courseId);
+
+  if (!course) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Header />
+        <main className="flex-grow container px-4 py-6">
+          <p>Course not found.</p>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-grow container px-4 py-6 md:py-8">
+        <Link to="/courses" className="text-sm text-primary mb-4 inline-block">← Back to Courses</Link>
+        <div className="max-w-3xl">
+          <h1 className="text-3xl font-bold mb-2">{course.title}</h1>
+          <p className="text-muted-foreground mb-4">{course.overview}</p>
+          <img src={course.image} alt={course.title} className="mb-6 rounded-lg" />
+          {course.modules.map((m, idx) => (
+            <div key={idx} className="mb-6">
+              <h2 className="font-semibold text-xl mb-2">Module {idx + 1}: {m.title}</h2>
+              <ul className="list-disc list-inside space-y-1">
+                {m.lessons.map((lesson, i) => (
+                  <li key={i}>{lesson}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </main>
+      <footer className="border-t border-border py-6">
+        <div className="container px-4 text-center text-sm text-muted-foreground">
+          <p>© 2025 Fintech Learn. All rights reserved.</p>
+        </div>
+      </footer>
+    </div>
+  );
+};
+
+export default CourseDetail;

--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -1,0 +1,32 @@
+import { Link } from 'react-router-dom';
+import { courses } from '@/data/courses';
+import Header from '@/components/Header';
+
+const Courses = () => {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-grow container px-4 py-6 md:py-8">
+        <h1 className="text-3xl md:text-4xl font-bold mb-6">Course Catalog</h1>
+        <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+          {courses.map(course => (
+            <Link key={course.id} to={`/courses/${course.id}`} className="crypto-card block overflow-hidden">
+              <img src={course.image} alt={course.title} className="h-40 w-full object-cover" />
+              <div className="p-4">
+                <h2 className="font-semibold text-lg mb-1">{course.title}</h2>
+                <p className="text-sm text-muted-foreground">{course.description}</p>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </main>
+      <footer className="border-t border-border py-6">
+        <div className="container px-4 text-center text-sm text-muted-foreground">
+          <p>© 2025 Fintech Learn. All rights reserved.</p>
+        </div>
+      </footer>
+    </div>
+  );
+};
+
+export default Courses;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,30 +4,11 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import Header from "@/components/Header";
 import TrendingCoins from "@/components/TrendingCoins";
 import MarketOverview from "@/components/MarketOverview";
-import LearnCard from "@/components/LearnCard";
-import { ArrowRight, BookOpen } from "lucide-react";
+import CourseCarousel from "@/components/CourseCarousel";
+import { ArrowRight } from "lucide-react";
 import { Link } from "react-router-dom";
 
 const Index = () => {
-  // Featured learning content
-  const featuredLearning = [
-    {
-      title: "Blockchain Fundamentals",
-      description: "Learn the core concepts behind blockchain technology and how it powers cryptocurrencies.",
-      category: "Blockchain",
-      timeToRead: "15 min",
-      difficulty: "beginner" as const,
-      link: "/learn/blockchain-fundamentals"
-    },
-    {
-      title: "Crypto Trading Basics",
-      description: "Understand the essentials of cryptocurrency trading and different market strategies.",
-      category: "Trading",
-      timeToRead: "20 min",
-      difficulty: "intermediate" as const,
-      link: "/learn/trading-basics"
-    }
-  ];
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -38,18 +19,17 @@ const Index = () => {
         <section className="mb-8">
           <div className="crypto-gradient rounded-lg p-6 md:p-8 text-white">
             <div className="max-w-3xl">
-              <h1 className="text-3xl md:text-4xl font-bold mb-4">Track, Learn, and Master Crypto</h1>
+              <h1 className="text-3xl md:text-4xl font-bold mb-4">Welcome to Fintech Learn</h1>
               <p className="text-lg opacity-90 mb-6">
-                Real-time market data and educational resources to help you navigate the world of cryptocurrency.
+                Discover interactive lessons on finance and technology while keeping an eye on today\'s crypto markets.
               </p>
               <div className="flex flex-col sm:flex-row gap-4">
                 <Button size="lg" className="bg-white text-crypto-primary hover:bg-white/90">
                   Get Started
                 </Button>
                 <Button size="lg" variant="outline" className="border-white text-white hover:bg-white/20" asChild>
-                  <Link to="/learn">
-                    <BookOpen className="mr-2 h-5 w-5" />
-                    Explore Tutorials
+                  <Link to="/courses">
+                    Explore Courses
                   </Link>
                 </Button>
               </div>
@@ -93,28 +73,24 @@ const Index = () => {
           <TrendingCoins />
         </section>
 
-        {/* Learning Section */}
+        {/* Courses Carousel */}
         <section>
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-2xl font-bold">Start Learning</h2>
+            <h2 className="text-2xl font-bold">Featured Courses</h2>
             <Button variant="ghost" asChild>
-              <Link to="/learn" className="flex items-center">
+              <Link to="/courses" className="flex items-center">
                 View All
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Link>
             </Button>
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-6">
-            {featuredLearning.map((item, index) => (
-              <LearnCard key={index} {...item} />
-            ))}
-          </div>
+          <CourseCarousel />
         </section>
       </main>
       
       <footer className="border-t border-border py-6">
         <div className="container px-4 text-center text-sm text-muted-foreground">
-          <p>© 2025 CryptoLearn. All rights reserved.</p>
+          <p>© 2025 Fintech Learn. All rights reserved.</p>
           <p className="mt-1">Market data provided for educational purposes only.</p>
         </div>
       </footer>

--- a/src/pages/Learn.tsx
+++ b/src/pages/Learn.tsx
@@ -122,7 +122,7 @@ const Learn = () => {
       
       <footer className="border-t border-border py-6 mt-auto">
         <div className="container px-4 text-center text-sm text-muted-foreground">
-          <p>© 2025 CryptoLearn. All rights reserved.</p>
+          <p>© 2025 Fintech Learn. All rights reserved.</p>
           <p className="mt-1">Educational content provided for informational purposes only.</p>
         </div>
       </footer>


### PR DESCRIPTION
## Summary
- update site metadata for Fintech Learn
- create course catalog and dynamic course detail pages
- add carousel for featured courses on the homepage
- fetch live crypto data from CoinGecko
- adjust navigation, headers, and footers

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488fb9bf7483279695d53785597094